### PR TITLE
doap: don't nest multiple versions in a release

### DIFF
--- a/doap_Gobblin.rdf
+++ b/doap_Gobblin.rdf
@@ -40,6 +40,8 @@
         <created>2023-08-30</created>
         <revision>0.17.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Apache Gobblin 0.16.0</name>
         <created>2022-02-03</created>


### PR DESCRIPTION
I'm having some trouble finding an authoritative reference, but it looks like a `release` (which is a property) may not contain multiple  `Version`s (which is a node) in RDF/XML. The python rdflib at least doesn't support it, and whatever generates https://projects.apache.org/json/projects/gobblin.json also doesn't seem to process it correctly.